### PR TITLE
ci: standardize runs-on to ebpro-org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     uses: ebpro/gh-actions-shared-java/.github/workflows/ci-shareable-maven.yml@develop
     secrets: inherit
     with:
-      runs-on: arc-runner-set-compute-lsis
+      runs-on: ebpro-org
       quality-goal-run: "true"
       deploy-goal-run: "true"
       site-goal-run: "true"


### PR DESCRIPTION
Converts selected self-hosted, empty, and legacy `arc-runner-set-compute-lsis` runner selections to `runs-on: ebpro-org`.

Changes:
- `.github/workflows/ci.yml` line 17: `      runs-on: arc-runner-set-compute-lsis` -> `      runs-on: ebpro-org`